### PR TITLE
Read configuration file & use data to publish data to a driver datasource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 server
 .idea
+config.json

--- a/config.json.dist
+++ b/config.json.dist
@@ -1,0 +1,7 @@
+{
+    "driver": "mongo",          # Specify which driver you'd like to use (mongo, elasticsearch)
+    "hostname": "127.0.0.1",    # Host for database server
+    "port": "27017",            # Port for database (27017 for Mongo)
+    "username": "",             # If database is configured with auth
+    "password": "",
+}

--- a/handlers.go
+++ b/handlers.go
@@ -3,11 +3,11 @@ package main
 import (
 	"compress/gzip"
 	"fmt"
-	"io"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
+	"io/ioutil"
+	"encoding/json"
 )
 
 func (e *Env) MetricHandler(w http.ResponseWriter, r *http.Request) {
@@ -15,11 +15,45 @@ func (e *Env) MetricHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Printf("Type of request: %s\n", vars["type"])
 	reader, err := gzip.NewReader(r.Body)
 	if err != nil {
-		panic(err)
+		w.WriteHeader(400)
+		w.Write([]byte("Bad application/gzip request"))
 	}
 
-	if _, err := io.Copy(os.Stdout, reader); err != nil {
-		panic(err)
+	raw, err := ioutil.ReadAll(reader)
+
+	if err != nil {
+		w.WriteHeader(400)
+		w.Write([]byte("Bad application/gzip request"))
 	}
+
+	var req map[string]interface{}
+	err = json.Unmarshal(raw, &req)
+
+	if err != nil {
+		w.WriteHeader(400)
+		w.Write([]byte("Could not unmarshal request"))
+	}
+
+	appName, ok := req["app_name"]
+
+	if !ok {
+		w.WriteHeader(400)
+		w.Write([]byte("Request missing required key: app_name"))
+	}
+
+	app, ok := appName.(string)
+
+	if !ok {
+		w.WriteHeader(400)
+		w.Write([]byte("app_name must be string"))
+	}
+
+	err = e.dataStore.Publish(raw, app)
+
+	if err != nil {
+		w.WriteHeader(500)
+		w.Write([]byte("Could not write to data store"))
+	}
+
 	return
 }

--- a/handlers.go
+++ b/handlers.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"encoding/json"
 	"github.com/gorilla/mux"
 	"io/ioutil"
-	"encoding/json"
 )
 
 func (e *Env) MetricHandler(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -7,27 +7,70 @@ import (
 	"github.com/auto-profile/server/driver"
 	stackimpact "github.com/auto-profile/stackimpact-go"
 	"github.com/gorilla/mux"
+	"flag"
+	"os"
+	"io/ioutil"
+	"encoding/json"
 )
 
 type Env struct {
 	dataStore driver.Datastore
 }
 
+var (
+	configPath string
+)
+
+func init() {
+	flag.StringVar(&configPath, "configPath", "config.json", "Path to configuration file")
+	flag.Parse()
+}
+
 func main() {
+	config, err := os.Open(configPath)
+
+	if err != nil {
+		panic(fmt.Sprintf("Could not open configuration file: %s", err))
+	}
+
+	raw, err := ioutil.ReadAll(config)
+
+	if err != nil {
+		panic(fmt.Sprintf("Could not read configuration file data: %s", err))
+	}
+
+	var credentials driver.DatastoreCredentials
+	err = json.Unmarshal(raw, &credentials)
+
+	if err != nil {
+		panic(fmt.Sprintf("Could not unmarshal configuration data: %s", err))
+	}
+
+	env := Env{}
+
+	switch credentials.Driver {
+	case "mongo":
+		env.dataStore = driver.NewMongoDriver()
+	default:
+		panic(fmt.Sprintf("Use of unsupported driver: %s", credentials.Driver))
+	}
+
+	err = env.dataStore.Connect(credentials)
+
+	if err != nil {
+		panic(err)
+	}
+
 	agent := stackimpact.NewAgent()
 	agent.Start(stackimpact.Options{
 		DashboardAddress: "http://localhost:8080",
 		AppName:          "test_server",
 	})
 
-	// TODO: Load config file here and create a Datastore
-
-	env := Env{}
-
 	router := mux.NewRouter().StrictSlash(true)
 	v1 := router.PathPrefix("/agent/v1").Subrouter()
 	v1.HandleFunc("/{type}", env.MetricHandler)
-	err := http.ListenAndServe(":8080", router)
+	err = http.ListenAndServe(":8080", router)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/main.go
+++ b/main.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"net/http"
 
+	"encoding/json"
+	"flag"
 	"github.com/auto-profile/server/driver"
 	stackimpact "github.com/auto-profile/stackimpact-go"
 	"github.com/gorilla/mux"
-	"flag"
-	"os"
 	"io/ioutil"
-	"encoding/json"
+	"os"
 )
 
 type Env struct {


### PR DESCRIPTION
- Ignore configuration file in gitignore
- Added config.json.dist example
- Handler uses env datastore publish & handles errors (more) gracefully
- Added configuration path flag & reading/unmarshalling
- Added switch for driver type